### PR TITLE
发布2.0.14版本

### DIFF
--- a/collector/agent_dimension_cache.go
+++ b/collector/agent_dimension_cache.go
@@ -1,0 +1,65 @@
+package collector
+
+import (
+	"sync"
+	"time"
+)
+
+type AgentDimensionRefresher struct {
+}
+
+const (
+	TooManyRequestsErrorCode = 429
+)
+
+var GetAgentDimensionRefresher = NewAgentDimensionRefresherGetter()
+
+func NewAgentDimensionRefresherGetter() func() *AgentDimensionRefresher {
+	var once sync.Once
+	var refresher *AgentDimensionRefresher
+	return func() *AgentDimensionRefresher {
+		once.Do(func() {
+			refresher = &AgentDimensionRefresher{}
+		})
+		return refresher
+	}
+}
+
+func (r *AgentDimensionRefresher) RefreshAgentDimensionWithInterval() {
+	go func() {
+		r.GetAgentDimension()
+		t := time.NewTicker(time.Duration(10) * time.Minute)
+		for range t.C {
+			r.GetAgentDimension()
+		}
+	}()
+}
+
+func (r *AgentDimensionRefresher) GetAgentDimension() {
+	syncInstanceAgentDimensions(&ecsInfo)
+	syncInstanceAgentDimensions(&bmsInfo)
+}
+
+func syncInstanceAgentDimensions(srvsInfo *serversInfo) {
+	var instanceIDs []string
+	srvsInfo.Lock()
+	if srvsInfo.LabelInfo != nil {
+		for instanceID := range srvsInfo.LabelInfo {
+			instanceIDs = append(instanceIDs, instanceID)
+		}
+	}
+	srvsInfo.Unlock()
+	// 发生限流时可重试，重试前等待时间递增，最多60s
+	waitSecondArrayForRetry := []int{1, 5, 10, 30, 60, 0}
+	for _, instanceID := range instanceIDs {
+		for _, waitSecond := range waitSecondArrayForRetry {
+			err := loadAgentDimensions(instanceID)
+			if err != nil && isErrorTypeForTooManyRequests(err) {
+				time.Sleep(time.Duration(waitSecond) * time.Second)
+				continue
+			}
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}

--- a/collector/agent_dimension_cache_test.go
+++ b/collector/agent_dimension_cache_test.go
@@ -1,0 +1,48 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+func TestAgentDimensionRefresher_GetAgentDimension(t *testing.T) {
+	patches := getPatches()
+	defer patches.Reset()
+	logs.InitLog("")
+	refresher := GetAgentDimensionRefresher()
+	refresher.GetAgentDimension()
+	assert.Empty(t, agentDimensions)
+
+	ecsInstances := []EcsInstancesInfo{
+		{
+			ResourceBaseInfo: ResourceBaseInfo{
+				ID:   "c53dbd97-c4ae-4ef7-8d12-fae2d3d38a80",
+				Name: "nodelete-DRS-autotest-datamode1-test2",
+				Tags: map[string]string{"wukong": "000"},
+				EpId: "0",
+			},
+			IP: "192.168.20.53,100.93.4.203",
+		},
+	}
+	ecsInfo.LabelInfo = map[string]labelInfo{
+		"instance001": {},
+	}
+	bmsInfo.LabelInfo = map[string]labelInfo{
+		"instance002": {},
+	}
+	patches.ApplyFuncReturn(getResourceFromRMS, true)
+	patches.ApplyFuncReturn(listResources, mockRmsResource(), nil)
+	patches.ApplyFuncReturn(getAllServer, ecsInstances, nil)
+	patches.ApplyFunc(loadAgentDimensions, func(instanceID string) error { return nil })
+	refresher.GetAgentDimension()
+	assert.Empty(t, agentDimensions)
+
+	patches.ApplyFuncReturn(listResources, nil, errors.New("xxx"))
+	patches.ApplyFuncReturn(getAllServer, nil, errors.New("xxx"))
+	refresher.GetAgentDimension()
+	assert.Empty(t, agentDimensions)
+}

--- a/collector/apic_test.go
+++ b/collector/apic_test.go
@@ -6,9 +6,13 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/apig/v2/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
 )
 
 func TestShowDetailsOfInstanceV2(t *testing.T) {
+	conf.AccessKey = "test_ak"
+	conf.SecretKey = "test_sk"
 	apigClient := getAPICSClient()
 	id := "0001-0001-0000001"
 	name := "instance01"
@@ -48,11 +52,13 @@ func TestGetResourceInfo(t *testing.T) {
 		},
 	}
 
-	patches := gomonkey.ApplyFuncReturn(getMetricConfigMap, sysConfig)
+	patches := getPatches()
+	patches.ApplyFuncReturn(getMetricConfigMap, sysConfig)
 	patches.ApplyFuncReturn(getAllAPICInstances, instances, nil)
 	patches.ApplyFuncReturn(getApisOfInstances, apis, nil)
 	patches.ApplyFuncReturn(showDetailsOfInstanceV2, &instance, nil)
 	defer patches.Reset()
+	logs.InitLog("")
 	var getter = APICInfo{}
 	label, metrics := getter.GetResourceInfo()
 	assert.Equal(t, 4, len(label))

--- a/collector/bms.go
+++ b/collector/bms.go
@@ -47,8 +47,41 @@ func (getter BMSInfo) GetResourceInfo() (map[string]labelInfo, []cesmodel.Metric
 
 type SERVICEBMSInfo struct{}
 
+var serviceBmsInfo serversInfo
+
 func (getter SERVICEBMSInfo) GetResourceInfo() (map[string]labelInfo, []cesmodel.MetricInfoList) {
+	serviceBmsInfo.Lock()
+	defer serviceBmsInfo.Unlock()
+	if serviceBmsInfo.LabelInfo == nil || time.Now().Unix() > serviceBmsInfo.TTL {
+		serviceBmsInfo.FilterMetrics = getServiceBMSMetrics()
+		serviceBmsInfo.LabelInfo = bmsInfo.LabelInfo
+		serviceBmsInfo.TTL = time.Now().Add(GetResourceInfoExpirationTime()).Unix()
+	}
+	return serviceBmsInfo.LabelInfo, serviceBmsInfo.FilterMetrics
+}
+
+func getServiceBMSMetrics() []cesmodel.MetricInfoList {
+	allMetrics, err := listAllMetrics("SERVICE.BMS")
+	var filteredMetrics []cesmodel.MetricInfoList
+	if err != nil {
+		logs.Logger.Errorf("Get all metrics of SERVICE.BMS error: %s", err.Error())
+		return filteredMetrics
+	}
+	if bmsInfo.LabelInfo == nil {
+		logs.Logger.Info("No bms resource info found, skip to query agent metrics info")
+		return filteredMetrics
+	}
 	bmsInfo.Lock()
 	defer bmsInfo.Unlock()
-	return bmsInfo.LabelInfo, nil
+	for _, metric := range allMetrics {
+		serverKey := getServerResourceKeyFromMetricInfo(metric)
+		if serverKey == "" {
+			continue
+		}
+		if _, ok := bmsInfo.LabelInfo[serverKey]; !ok {
+			continue
+		}
+		filteredMetrics = append(filteredMetrics, metric)
+	}
+	return filteredMetrics
 }

--- a/collector/bms_test.go
+++ b/collector/bms_test.go
@@ -3,18 +3,28 @@ package collector
 import (
 	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/ces/v1/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
 )
 
 func TestBmsGetResourceInfo(t *testing.T) {
-	sysConfig := map[string][]string{"instance_id": {"cpu_utils"}}
 	instances := []EcsInstancesInfo{
 		{ResourceBaseInfo: ResourceBaseInfo{ID: "0001-0001-000000001", Name: "host01", EpId: "0"}},
 	}
-	patches := gomonkey.ApplyFuncReturn(getMetricConfigMap, sysConfig)
+	metricConf = map[string]MetricConf{
+		"SYS.BMS": {
+			Resource: "rms",
+			DimMetricName: map[string][]string{
+				"instance_id": {"cpu_utils"},
+			},
+		},
+	}
+
+	patches := getPatches()
+	logs.InitLog("")
 	patches.ApplyFuncReturn(getAllServerFromRMS, instances, nil)
-	patches.ApplyFunc(loadAgentDimensions, func(_ string) error { return nil })
 	patches.ApplyFuncReturn(getIPFromEcsInfo, "")
 	defer patches.Reset()
 
@@ -24,6 +34,19 @@ func TestBmsGetResourceInfo(t *testing.T) {
 	assert.Equal(t, 1, len(metrics))
 
 	var servicesGetter SERVICEBMSInfo
+	patches.ApplyFuncReturn(listAllMetrics, []model.MetricInfoList{
+		{
+			Dimensions: []model.MetricsDimension{
+				{
+					Name:  "instance_id",
+					Value: "111111",
+				},
+			},
+			Namespace:  "SERVICE.BMS",
+			MetricName: "cpu_usage",
+		},
+	}, nil)
+
 	serviceLabel, _ := servicesGetter.GetResourceInfo()
 	assert.Equal(t, 1, len(serviceLabel))
 }

--- a/collector/ecs.go
+++ b/collector/ecs.go
@@ -179,8 +179,26 @@ func (getter AGTECSInfo) GetResourceInfo() (map[string]labelInfo, []model.Metric
 
 func getECSAGTMetrics() []model.MetricInfoList {
 	allMetrics, err := listAllMetrics("AGT.ECS")
+	var filteredMetrics []model.MetricInfoList
 	if err != nil {
-		logs.Logger.Errorf("[%s] Get all metrics of AGT.ECS error: %s", err.Error())
+		logs.Logger.Errorf("Get all metrics of AGT.ECS error: %s", err.Error())
+		return filteredMetrics
 	}
-	return allMetrics
+	if ecsInfo.LabelInfo == nil {
+		logs.Logger.Info("No ecs resource info found, skip to query agent metrics info")
+		return filteredMetrics
+	}
+	ecsInfo.Lock()
+	defer ecsInfo.Unlock()
+	for _, metric := range allMetrics {
+		serverKey := getServerResourceKeyFromMetricInfo(metric)
+		if serverKey == "" {
+			continue
+		}
+		if _, ok := ecsInfo.LabelInfo[serverKey]; !ok {
+			continue
+		}
+		filteredMetrics = append(filteredMetrics, metric)
+	}
+	return filteredMetrics
 }

--- a/collector/ecs_test.go
+++ b/collector/ecs_test.go
@@ -53,9 +53,9 @@ func TestAGTECSInfo_GetResourceInfo(t *testing.T) {
 			},
 		},
 	}
-	patches := gomonkey.ApplyFuncReturn(getECSAGTMetrics, []model.MetricInfoList{metricInfosList})
+	patches := gomonkey.ApplyFuncReturn(listAllMetrics, []model.MetricInfoList{metricInfosList}, nil)
 	defer patches.Reset()
 	agtEcsInfo1 := AGTECSInfo{}
-	_, filterMetrics := agtEcsInfo1.GetResourceInfo()
-	assert.NotNil(t, filterMetrics)
+	resourceInfo, _ := agtEcsInfo1.GetResourceInfo()
+	assert.NotNil(t, resourceInfo)
 }

--- a/collector/ewp.go
+++ b/collector/ewp.go
@@ -1,0 +1,146 @@
+package collector
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/ces/v1/model"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+type EwpSiteInfoRequest struct{}
+
+type EwpSiteInfoResponse struct {
+	DisplayName    string `json:"displayName"`
+	HttpStatusCode int    `json:"-"`
+}
+
+type EwpDomainInfoRequest struct{}
+
+type EwpDomainInfo struct {
+	Name      string `json:"name"`
+	XDomainID string `json:"xdomain_id"`
+}
+
+type EwpDomainInfoResponse struct {
+	Domains        []EwpDomainInfo `json:"domains"`
+	HttpStatusCode int             `json:"-"`
+}
+
+var ewpInfo serversInfo
+
+type EWPInfo struct{}
+
+func (getter EWPInfo) GetResourceInfo() (map[string]labelInfo, []model.MetricInfoList) {
+	resourceInfos := map[string]labelInfo{}
+	filterMetrics := make([]model.MetricInfoList, 0)
+	ewpInfo.Lock()
+	defer ewpInfo.Unlock()
+	if ewpInfo.LabelInfo == nil || time.Now().Unix() > ewpInfo.TTL {
+		sysConfigMap := getMetricConfigMap("SYS.EWP")
+		if sysConfigMap == nil {
+			logs.Logger.Warn("Metric config is nil.")
+			return ewpInfo.LabelInfo, ewpInfo.FilterMetrics
+		}
+		allMetrics, listMetricErr := listAllMetrics("SYS.EWP")
+		if listMetricErr != nil {
+			logs.Logger.Errorf("Failed to get site resources, error: %s", listMetricErr.Error())
+			return nil, nil
+		}
+		metricGroups := getEwpMetricsGroups(allMetrics)
+		siteMetrics, ok := metricGroups["site_id"]
+		var siteIds []string
+		if ok {
+			siteIdMap := make(map[string]bool, 0)
+			for _, siteMetric := range siteMetrics {
+				siteId := siteMetric.Dimensions[0].Value
+				if _, inMap := siteIdMap[siteId]; inMap {
+					continue
+				}
+				siteIdMap[siteId] = true
+				siteIds = append(siteIds, siteMetric.Dimensions[0].Value)
+			}
+		}
+
+		userInfoMap := getUserInfoFromIAM()
+		for domainId, domainName := range userInfoMap {
+			if metricNames, ok := sysConfigMap["user_id"]; ok {
+				metrics := buildSingleDimensionMetrics(metricNames, "SYS.EWP", "user_id", domainId)
+				filterMetrics = append(filterMetrics, metrics...)
+				info := labelInfo{
+					Name:  []string{"name"},
+					Value: []string{domainName},
+				}
+				resourceInfos[GetResourceKeyFromMetricInfo(metrics[0])] = info
+			}
+		}
+
+		siteInfos, siErr := getAllSiteInfos(siteIds)
+		if siErr != nil {
+			logs.Logger.Errorf("Get site infos error: %s", siErr.Error())
+			return ewpInfo.LabelInfo, ewpInfo.FilterMetrics
+		}
+		for _, siteInfo := range siteInfos {
+			if metricNames, ok := sysConfigMap["site_id"]; ok {
+				metrics := buildSingleDimensionMetrics(metricNames, "SYS.EWP", "site_id", siteInfo.ID)
+				filterMetrics = append(filterMetrics, metrics...)
+				info := labelInfo{
+					Name:  []string{"name"},
+					Value: []string{siteInfo.Name},
+				}
+				resourceInfos[GetResourceKeyFromMetricInfo(metrics[0])] = info
+			}
+		}
+
+		ewpInfo.LabelInfo = resourceInfos
+		ewpInfo.FilterMetrics = filterMetrics
+		ewpInfo.TTL = time.Now().Add(GetResourceInfoExpirationTime()).Unix()
+	}
+	return ewpInfo.LabelInfo, ewpInfo.FilterMetrics
+}
+
+func getEwpMetricsGroups(metrics []model.MetricInfoList) map[string][]model.MetricInfoList {
+	resultMap := make(map[string][]model.MetricInfoList, 0)
+	for _, metric := range metrics {
+		if len(metric.Dimensions) < 1 {
+			continue
+		}
+		dimName := metric.Dimensions[0].Name
+		if metricInfoList, ok := resultMap[dimName]; ok {
+			metricInfoList = append(metricInfoList, metric)
+			resultMap[dimName] = metricInfoList
+		} else {
+			resultMap[dimName] = []model.MetricInfoList{metric}
+		}
+	}
+	return resultMap
+}
+
+func getAllSiteInfos(instanceIds []string) ([]ResourceBaseInfo, error) {
+	var results []ResourceBaseInfo
+	for _, instanceId := range instanceIds {
+		urlPath := fmt.Sprintf("/v1/cloudsite/%s/display-name", instanceId)
+		requestDef := def.NewHttpRequestDefBuilder().
+			WithMethod(http.MethodGet).
+			WithPath(urlPath).
+			WithResponse(new(EwpSiteInfoResponse)).
+			WithContentType("application/json").Build()
+		req := EwpSiteInfoRequest{}
+		resp, err := getHcClient(getEndpoint("ewp", "v1")).Sync(req, requestDef)
+		if err != nil {
+			logs.Logger.Errorf("Get ewp site display name error: %s", err.Error())
+			return nil, err
+		}
+		siteInfo, ok := resp.(*EwpSiteInfoResponse)
+		if !ok {
+			logs.Logger.Errorf("Get all ewp site convert to EwpSiteInfoResponse failed!")
+			return results, fmt.Errorf("convert to EwpSiteInfoResponse failed")
+		}
+		results = append(results, ResourceBaseInfo{ID: instanceId, Name: siteInfo.DisplayName})
+	}
+
+	return results, nil
+}

--- a/collector/ewp_test.go
+++ b/collector/ewp_test.go
@@ -1,0 +1,53 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/ces/v1/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEWPInfo_GetResourceInfo(t *testing.T) {
+	var ewpGetter EWPInfo
+	metricConf = map[string]MetricConf{
+		"SYS.EWP": {
+			DimMetricName: map[string][]string{"user_id": {"total_request_success_rate"}, "site_id": {"website_design_clicks"}},
+		},
+	}
+	sysConfig := map[string][]string{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFuncReturn(getMetricConfigMap, sysConfig)
+	patches.ApplyFuncReturn(listResources, mockRmsResource(), nil)
+	patches.ApplyFuncReturn(getUserInfoFromIAM, map[string]string{"test_domain_id": "test_domain_name"})
+	patches.ApplyFuncReturn(listAllMetrics, []model.MetricInfoList{
+		{
+			Dimensions: []model.MetricsDimension{
+				{
+					Name:  "user_id",
+					Value: "111111",
+				},
+			},
+			Namespace:  "SYS.EWP",
+			MetricName: "total_request_success_rate",
+		},
+		{
+			Dimensions: []model.MetricsDimension{
+				{
+					Name:  "site_id",
+					Value: "222222",
+				},
+			},
+			Namespace:  "SYS.EWP",
+			MetricName: "website_design_clicks",
+		},
+	}, nil)
+	hcClient := &core.HcHttpClient{}
+	patches.ApplyMethodReturn(hcClient, "Sync", &EwpSiteInfoResponse{}, nil)
+	patches.ApplyFuncReturn(getHcClient, hcClient)
+	info, lists := ewpGetter.GetResourceInfo()
+	assert.NotNil(t, info)
+	assert.NotNil(t, lists)
+}

--- a/collector/https_server.go
+++ b/collector/https_server.go
@@ -1,0 +1,214 @@
+package collector
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+var (
+	caPath            string
+	serverCertPath    string
+	serverKeyPath     string
+	serverKeyPassword string
+)
+
+func StartHttpsServer() error {
+	caBytes, certBytes, keyBytes, loadErr := loadHttpsCerts()
+	if loadErr != nil {
+		logs.Logger.Errorf("Load https certificates failed, error is: %s", loadErr.Error())
+		return loadErr
+	}
+	startErr := listenAndServeTLS(caBytes, certBytes, keyBytes)
+	if startErr != nil {
+		logs.Logger.Errorf("Listen and serve tls failed, error is: %s", startErr.Error())
+		return startErr
+	}
+	return nil
+}
+
+func loadHttpsCerts() ([]byte, []byte, []byte, error) {
+	// 命令行读取CA证书路径，https证书路径，https私钥路径和私钥密码
+	readHttpsParametersFromCmd()
+	// 保证读取完毕后，明文证书+私钥被删除
+	defer cleanHttpsConfFiles()
+	// 通过路径读取证书+私钥内容
+	return loadHttpsCertsAndKey()
+}
+
+func readHttpsParametersFromCmd() {
+	var err error
+	fmt.Print("Please input CA certification path, https server certificate path, " +
+		"https server private key path and private key password split with spaces.\n" +
+		"eg: {example_ca_path example_server_cert_path example_server_key_path example_private_key_password}\n")
+	reader := bufio.NewReader(os.Stdin)
+	httpsParameters, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Printf("Error occurred when scan https parameters: %s", err.Error())
+		return
+	}
+	httpsParameterArray := strings.Split(httpsParameters, " ")
+	if len(httpsParameterArray) < 4 {
+		fmt.Printf("Read https parameters error, you should enter the https parameters in the following mode:\n" +
+			"{example_ca_path example_server_cert_path example_server_key_path example_private_key_password}\n")
+		return
+	}
+	caPath = httpsParameterArray[0]
+	serverCertPath = httpsParameterArray[1]
+	serverKeyPath = httpsParameterArray[2]
+	serverKeyPassword = httpsParameterArray[3]
+}
+
+func loadHttpsCertsAndKey() ([]byte, []byte, []byte, error) {
+	var err error
+	caPath, err = NormalizePath(caPath)
+	if err != nil {
+		logs.Logger.Error("The ca certificate file path is abnormal and error is:", err.Error())
+		return nil, nil, nil, err
+	}
+	caBytes, err := os.ReadFile(caPath)
+	if err != nil {
+		logs.Logger.Error("Read ca certificate file failed and error is:", err.Error())
+		return nil, nil, nil, err
+	}
+
+	serverCertPath, err = NormalizePath(serverCertPath)
+	if err != nil {
+		logs.Logger.Error("The https server certificate file path is abnormal and error is:", err.Error())
+		return nil, nil, nil, err
+	}
+	serverCertBytes, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		logs.Logger.Error("Read https server certificate file failed and error is:", err.Error())
+		return nil, nil, nil, err
+	}
+
+	serverKeyPath, err = NormalizePath(serverKeyPath)
+	if err != nil {
+		logs.Logger.Error("The https server private key file path is abnormal and error is:", err.Error())
+		return nil, nil, nil, err
+	}
+
+	serverKeyBytes, err := getServerKeyBytes(serverKeyPath, serverKeyPassword)
+	if err != nil {
+		logs.Logger.Error("Open ssl get https server private key failed, and error is: ", err.Error())
+		return nil, nil, nil, err
+	}
+	return caBytes, serverCertBytes, serverKeyBytes, nil
+}
+
+func cleanHttpsConfFiles() {
+	err := os.Remove(caPath)
+	if err != nil {
+		logs.Logger.Errorf("Remove plaintext ca file error: %s", err.Error())
+	}
+
+	err = os.Remove(serverCertPath)
+	if err != nil {
+		logs.Logger.Errorf("Remove plaintext server crt file error: %s", err.Error())
+	}
+	err = os.Remove(serverKeyPath)
+	if err != nil {
+		logs.Logger.Errorf("Remove plaintext server private key file error: %s", err.Error())
+	}
+}
+
+func getServerKeyBytes(serverKeyPath, serverKeyPassword string) ([]byte, error) {
+	cmd := exec.Command("openssl", "rsa", "-in", serverKeyPath, "-passin", "stdin")
+	cmd.Stdin = strings.NewReader(strings.Replace(serverKeyPassword, "'", "'\\''", -1))
+	var (
+		stdout, stderr bytes.Buffer
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		logs.Logger.Error("Execute cmd failed and error is: ", err.Error())
+		return nil, err
+	}
+
+	return stdout.Bytes(), nil
+}
+
+func listenAndServeTLS(caCert, serverCert, serverKey []byte) error {
+	certificate, err := tls.X509KeyPair(serverCert, serverKey)
+	if err != nil {
+		return err
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCert)
+
+	cfg := &tls.Config{
+		ClientCAs:          pool,
+		ClientAuth:         tls.RequireAndVerifyClientCert,
+		InsecureSkipVerify: false,
+		Certificates:       []tls.Certificate{certificate},
+		MinVersion:         tls.VersionTLS12,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		},
+		VerifyPeerCertificate: verifyPeerCert,
+	}
+	server := &http.Server{
+		Addr:         CloudConf.Global.Port,
+		TLSConfig:    cfg,
+		WriteTimeout: 30 * time.Second,
+		ReadTimeout:  30 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	return server.ListenAndServeTLS("", "")
+}
+
+func verifyPeerCert(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
+		logs.Logger.Error("No verified chains")
+		return fmt.Errorf("no verified chains")
+	}
+	cnArray := strings.Split(CloudConf.Global.ClientCN, ",")
+	for i := range verifiedChains {
+		for j := range verifiedChains[i] {
+			for _, dnsName := range verifiedChains[i][j].DNSNames {
+				if !strSliceContains(cnArray, dnsName) {
+					logs.Logger.Errorf("Invalid dnsName current is %s", dnsName)
+					return fmt.Errorf("invalid dnsName current is %s", dnsName)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type TcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln TcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		logs.Logger.Errorf("Tcp listener accept tcp error: %s", err.Error())
+		return
+	}
+	err = tc.SetKeepAlive(true)
+	if err != nil {
+		logs.Logger.Errorf("Tcp connector set keep alive error: %s", err.Error())
+		return
+	}
+	err = tc.SetKeepAlivePeriod(3 * time.Minute)
+	if err != nil {
+		logs.Logger.Errorf("Tcp connector set keep alive period error: %s", err.Error())
+		return
+	}
+	return tc, nil
+}

--- a/collector/https_server_test.go
+++ b/collector/https_server_test.go
@@ -1,0 +1,299 @@
+package collector
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+func TestStartHttpsServer(t *testing.T) {
+	testCases := []struct {
+		name    string
+		patches func() *gomonkey.Patches
+		expect  func(t *testing.T, err error)
+	}{
+		{
+			"start_success",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "Serve", func(srv *http.Server,
+					l net.Listener) error {
+					return nil
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {})
+				patches.ApplyFuncReturn(net.Listen, &net.TCPListener{}, nil)
+				patches.ApplyMethod(reflect.TypeOf(&bufio.Reader{}), "ReadString", func(reader *bufio.Reader,
+					delim byte) (string,
+					error) {
+					return "ca crt key password", nil
+				})
+				patches.ApplyFuncReturn(os.ReadFile, []byte{}, nil)
+				patches.ApplyFuncReturn(os.Remove, nil)
+				patches.ApplyFuncReturn(tls.X509KeyPair, tls.Certificate{}, nil)
+				patches.ApplyFuncReturn(getServerKeyBytes, []byte("test"), nil)
+				HttpsEnabled = true
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			"read_https_conf_error",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "Serve", func(srv *http.Server,
+					l net.Listener) error {
+					return nil
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {})
+				patches.ApplyFuncReturn(net.Listen, &net.TCPListener{}, nil)
+				patches.ApplyMethod(reflect.TypeOf(&bufio.Reader{}), "ReadString", func(reader *bufio.Reader,
+					delim byte) (string,
+					error) {
+					return "", errors.New("read error")
+				})
+				patches.ApplyFuncReturn(os.ReadFile, []byte{}, nil)
+				patches.ApplyFuncReturn(os.Remove, nil)
+				patches.ApplyFuncReturn(tls.X509KeyPair, tls.Certificate{}, nil)
+				patches.ApplyFuncReturn(getServerKeyBytes, []byte("test"), nil)
+				HttpsEnabled = true
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			"read_https_conf_length_error",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "Serve", func(srv *http.Server,
+					l net.Listener) error {
+					return nil
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {})
+				patches.ApplyFuncReturn(net.Listen, &net.TCPListener{}, nil)
+				patches.ApplyMethod(reflect.TypeOf(&bufio.Reader{}), "ReadString", func(reader *bufio.Reader,
+					delim byte) (string,
+					error) {
+					return "aaa", nil
+				})
+				patches.ApplyFuncReturn(os.ReadFile, []byte{}, nil)
+				patches.ApplyFuncReturn(os.Remove, nil)
+				patches.ApplyFuncReturn(tls.X509KeyPair, tls.Certificate{}, nil)
+				patches.ApplyFuncReturn(getServerKeyBytes, []byte("test"), nil)
+				HttpsEnabled = true
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			"start_without_security_mode",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "Serve", func(srv *http.Server,
+					l net.Listener) error {
+					return nil
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {})
+				patches.ApplyFuncReturn(net.Listen, &net.TCPListener{}, nil)
+				patches.ApplyMethod(reflect.TypeOf(&bufio.Reader{}), "ReadString", func(reader *bufio.Reader,
+					delim byte) (string,
+					error) {
+					return "aaa", nil
+				})
+				patches.ApplyFuncReturn(os.ReadFile, []byte{}, nil)
+				patches.ApplyFuncReturn(os.Remove, nil)
+				patches.ApplyFuncReturn(tls.X509KeyPair, tls.Certificate{}, nil)
+				patches.ApplyFuncReturn(getServerKeyBytes, []byte("test"), nil)
+				HttpsEnabled = false
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+			logs.InitLog("")
+			err := StartHttpsServer()
+			testCase.expect(t, err)
+		})
+	}
+}
+
+func TestTcpKeepAliveListener_Accept(t *testing.T) {
+	testCases := []struct {
+		name    string
+		patches func() *gomonkey.Patches
+		expect  func(t *testing.T, err error)
+	}{
+		{
+			"accept_tpc_error",
+			func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPListener{}), "AcceptTCP",
+					func(listener *net.TCPListener) (*net.TCPConn, error) {
+						return nil, errors.New("accept error")
+					})
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+			},
+		},
+		{
+			"set_keep_alive_error",
+			func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPListener{}), "AcceptTCP", func(listener *net.TCPListener) (*net.TCPConn, error) {
+					return &net.TCPConn{}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPConn{}), "SetKeepAlive", func(conn *net.TCPConn,
+					keepalive bool) error {
+					return errors.New("set keep alive error")
+				})
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+			},
+		},
+		{
+			"set_keep_alive_period_error",
+			func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPListener{}), "AcceptTCP", func(listener *net.TCPListener) (*net.
+					TCPConn, error) {
+					return &net.TCPConn{}, nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPConn{}), "SetKeepAlive", func(conn *net.TCPConn,
+					keepalive bool) error {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPConn{}), "SetKeepAlivePeriod", func(conn *net.TCPConn, d time.Duration) error {
+					return errors.New("set keep alive period error")
+				})
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+			},
+		},
+		{
+			"success",
+			func() *gomonkey.Patches {
+				patches := gomonkey.NewPatches()
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPListener{}), "AcceptTCP",
+					func(listener *net.TCPListener) (*net.TCPConn, error) {
+						return &net.TCPConn{}, nil
+					})
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPConn{}), "SetKeepAlive", func(conn *net.TCPConn, keepalive bool) error {
+					return nil
+				})
+				patches.ApplyMethod(reflect.TypeOf(&net.TCPConn{}), "SetKeepAlivePeriod", func(conn *net.TCPConn, d time.Duration) error {
+					return nil
+				})
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+			ln := TcpKeepAliveListener{}
+			_, err := ln.Accept()
+			testCase.expect(t, err)
+		})
+	}
+}
+
+func TestCliExecutor(t *testing.T) {
+	testCases := []struct {
+		name    string
+		patches func() *gomonkey.Patches
+		expect  func(t *testing.T, err error)
+	}{
+		{
+			"cmd_run_success",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				cmd := &exec.Cmd{}
+				patches.ApplyMethod(reflect.TypeOf(cmd), "Run", func(cmd *exec.Cmd) error {
+					return nil
+				})
+				patches.ApplyFuncReturn(exec.Command, cmd)
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.Nil(t, err)
+			},
+		},
+		{
+			"cmd_run_error",
+			func() *gomonkey.Patches {
+				patches := getPatches()
+				cmd := &exec.Cmd{}
+				patches.ApplyMethod(reflect.TypeOf(cmd), "Run", func(cmd *exec.Cmd) error {
+					return errors.New("run cmd error")
+				})
+				patches.ApplyFuncReturn(exec.Command, cmd)
+				return patches
+			},
+			func(t *testing.T, err error) {
+				assert.NotNil(t, err)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+			logs.InitLog("")
+			_, err := getServerKeyBytes("./server.key", "aaa")
+			testCase.expect(t, err)
+		})
+	}
+}
+
+func TestVerifyPeerCrt(t *testing.T) {
+	verifiedChains := [][]*x509.Certificate{
+		{
+			{
+				DNSNames: []string{"aaa", "bbb"},
+			},
+			{
+				DNSNames: []string{"ccc", "ddd"},
+			},
+		},
+	}
+	CloudConf.Global.ClientCN = "aaa,bbb,ccc,ddd"
+	err := verifyPeerCert(nil, verifiedChains)
+	assert.Nil(t, err)
+
+	err = verifyPeerCert(nil, [][]*x509.Certificate{})
+	assert.NotNil(t, err)
+}

--- a/collector/server.go
+++ b/collector/server.go
@@ -1,0 +1,35 @@
+package collector
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+func StartServer() {
+	var err error
+	if HttpsEnabled {
+		err = StartHttpsServer()
+	} else {
+		err = StartHttpServer()
+	}
+	if err != nil {
+		logs.Logger.Errorf("Start server failed, error is: %s", err.Error())
+		logs.FlushLogAndExit(1)
+	}
+}
+
+func StartHttpServer() error {
+	server := &http.Server{
+		Addr:         CloudConf.Global.Port,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 60 * time.Second,
+	}
+	logs.Logger.Infof("Start server at %s", CloudConf.Global.Port)
+	if err := server.ListenAndServe(); err != nil {
+		logs.Logger.Errorf("Error occur when start server %s", err.Error())
+		return err
+	}
+	return nil
+}

--- a/collector/server_test.go
+++ b/collector/server_test.go
@@ -1,0 +1,97 @@
+package collector
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/huaweicloud/cloudeye-exporter/logs"
+)
+
+func TestStartServer(t *testing.T) {
+	successFlag := true
+	testCases := []struct {
+		name    string
+		patches func() *gomonkey.Patches
+		expect  func(t *testing.T)
+	}{
+		{
+			"start_https_success",
+			func() *gomonkey.Patches {
+				HttpsEnabled = true
+				patches := getPatches()
+				patches.ApplyFuncReturn(StartHttpsServer, nil)
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {
+					successFlag = false
+				})
+				return patches
+			},
+			func(t *testing.T) {
+				assert.True(t, successFlag)
+			},
+		},
+		{
+			"start_https_failed",
+			func() *gomonkey.Patches {
+				HttpsEnabled = true
+				patches := getPatches()
+				patches.ApplyFuncReturn(StartHttpsServer, errors.New("start https server error"))
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {
+					successFlag = false
+				})
+				return patches
+			},
+			func(t *testing.T) {
+				assert.False(t, successFlag)
+			},
+		},
+		{
+			"start_http_success",
+			func() *gomonkey.Patches {
+				HttpsEnabled = false
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "ListenAndServe", func(server *http.Server) error {
+					return nil
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {
+					successFlag = false
+				})
+				return patches
+			},
+			func(t *testing.T) {
+				assert.True(t, successFlag)
+			},
+		},
+		{
+			"start_http_failed",
+			func() *gomonkey.Patches {
+				HttpsEnabled = false
+				patches := getPatches()
+				patches.ApplyMethod(reflect.TypeOf(&http.Server{}), "ListenAndServe", func(server *http.Server) error {
+					return errors.New("start http server error")
+				})
+				patches.ApplyFunc(logs.FlushLogAndExit, func(code int) {
+					successFlag = false
+				})
+				return patches
+			},
+			func(t *testing.T) {
+				assert.False(t, successFlag)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			patches := testCase.patches()
+			defer patches.Reset()
+			logs.InitLog("")
+			successFlag = true
+			StartServer()
+			testCase.expect(t)
+		})
+	}
+}

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -96,6 +96,15 @@ func getServerResourceKey(metric model.BatchMetricData) string {
 	return ""
 }
 
+func getServerResourceKeyFromMetricInfo(metric model.MetricInfoList) string {
+	for _, dim := range metric.Dimensions {
+		if dim.Name == "instance_id" {
+			return dim.Value
+		}
+	}
+	return ""
+}
+
 func getDmsResourceKey(metric model.BatchMetricData) string {
 	for _, dim := range *metric.Dimensions {
 		if dim.Name == "kafka_instance_id" || dim.Name == "rabbitmq_instance_id" || dim.Name == "reliablemq_instance_id" {

--- a/collector/utils_test.go
+++ b/collector/utils_test.go
@@ -189,7 +189,7 @@ func TestFmtTags(t *testing.T) {
 
 	valueA := "value_a"
 	tagInfo := []cbrmodel.Tag{
-		{Key: "key_a", Value: valueA},
+		{Key: "key_a", Value: &valueA},
 	}
 	tags = fmtTags(tagInfo)
 	assert.Equal(t, "value_a", tags["key_a"])
@@ -325,6 +325,53 @@ func TestStrSliceContains(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			result := strSliceContains(testCase.slice, testCase.str)
 			testCase.expect(t, result)
+		})
+	}
+}
+
+func TestGetServerResourceKeyFromMetricInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		metricInfoList model.MetricInfoList
+		expect         func(t *testing.T, resourceKey string)
+	}{
+		{
+			"no_instance_id_dim_name",
+			model.MetricInfoList{
+				Namespace:  namespace,
+				MetricName: "cpu_usage",
+				Dimensions: []model.MetricsDimension{
+					{
+						Name:  "instance_id1",
+						Value: "9234ad9f-87a5-49a9-b6ec-11ecde1d943b",
+					},
+				},
+			},
+			func(t *testing.T, resourceKey string) {
+				assert.Equal(t, "", resourceKey)
+			},
+		},
+		{
+			"has_instance_id_dim_name",
+			model.MetricInfoList{
+				Namespace:  namespace,
+				MetricName: "cpu_usage",
+				Dimensions: []model.MetricsDimension{
+					{
+						Name:  "instance_id",
+						Value: "9234ad9f-87a5-49a9-b6ec-11ecde1d943b",
+					},
+				},
+			},
+			func(t *testing.T, resourceKey string) {
+				assert.NotEqual(t, "", resourceKey)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resourceKey := getServerResourceKeyFromMetricInfo(testCase.metricInfoList)
+			testCase.expect(t, resourceKey)
 		})
 	}
 }

--- a/collector/version.go
+++ b/collector/version.go
@@ -1,5 +1,5 @@
 package collector
 
 const (
-	Version = "v2.0.13"
+	Version = "v2.0.14"
 )

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.19
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.11.0
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.92
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.110
 	github.com/prometheus/client_golang v1.17.0
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -30,7 +30,7 @@ require (
 	go.mongodb.org/mongo-driver v1.12.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.18.0 // indirect
+	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/grafana_dashboard/templates/ewp_dashboard_template.json
+++ b/grafana_dashboard/templates/ewp_dashboard_template.json
@@ -1,0 +1,673 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "title": "站点指标",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_website_design_clicks",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "网站设计点击次数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_website_design_request_failed_rate",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "网站设计请求失败率",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "panels": [],
+      "title": "用户指标",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_total_request_success_rate",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "总体请求成功率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_site_list_clicks",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "站点列表点击次数",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_site_list_request_failed_rate",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "站点列表请求失败率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "huaweicloud_sys_ewp_template_list_clicks",
+          "instant": false,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "模板列表点击次数",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "企业门户（EWP）",
+  "uid": "f60c79e9-8711-4976-92af-fb63b74d9f48",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
1. 优化弹性云服务器指标（SYS.ECS、AGT.ECS）导出逻辑，减少部分接口集中请求而导致的流控现象；
2. AGT.ECS和SERVICE.BMS支持按企业项目过滤并导出指标数据
3. 支持导出企业门户（SYS.EWP）相关指标；
4. 处理云连接（SYS.CC）指标导出功能中，只能导出单端域间带宽指标的问题；
5. 支持以https（需双向认证证书）形式启动exporter。