### PR TITLE
feat: add support for ECS agency authentication

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -476,6 +476,20 @@ var authCredentialMap = map[string]func(serviceType string) auth.ICredential{
 		}
 		return credential
 	},
+	AuthModeEcsAgency: func(serviceType string) auth.ICredential {
+		var credential auth.ICredential
+		// When AK and SK are not set, the Huawei Cloud Go SDK will automatically
+		// invoke the Metadata service to obtain a temporary AK/SK
+		switch serviceType {
+		case GlobalServiceType:
+			credential = global.NewCredentialsBuilder().WithDomainId(conf.DomainID).Build()
+		case RegionServiceType:
+			credential = basic.NewCredentialsBuilder().WithProjectId(conf.ProjectID).Build()
+		default:
+			logs.Logger.Errorf("Invalid service type: %s", serviceType)
+		}
+		return credential
+	},
 	AuthModeOidcToken: func(serviceType string) auth.ICredential {
 		var credential auth.ICredential
 		switch serviceType {
@@ -511,6 +525,9 @@ func InitConfig() error {
 			conf.AccessKey = CloudConf.Auth.AccessKey
 			conf.SecretKey = CloudConf.Auth.SecretKey
 		}
+	} else if AuthMode == AuthModeEcsAgency {
+		conf.AuthMode = AuthModeEcsAgency
+		// AK/SK are obtained from ECS Metadata service
 	} else {
 		fmt.Printf("Auth mode is invalid: %s", AuthMode)
 		return errors.New("Auth mode is invalid")

--- a/collector/utils.go
+++ b/collector/utils.go
@@ -26,6 +26,7 @@ const (
 	MaxEpsCount                     = 10000
 
 	AuthModePermanentAkSk = "aksk"
+	AuthModeEcsAgency     = "ecsagency"
 	AuthModeOidcToken     = "oidc"
 	GlobalServiceType     = "GlobalService"
 	RegionServiceType     = "RegionService"


### PR DESCRIPTION
Instead of using a permanent AK/SK (which goes against the [best practices of IAM service](https://support.huaweicloud.com/intl/en-us/bestpractice-iam/iam_0426.html#section8) of "Periodically Change Your Identity Credentials"), if the cloudeye-exporter application is running in an ECS, the [Security Key endpoint from ECS Metadata API](https://support.huaweicloud.com/intl/en-us/usermanual-ecs/ecs_03_0166.html#section7) can be used to obtain a temporary AK/SK with [permissions given to the Agency](https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_06_0004.html) assigned to the ECS instance.

To use the ECS agency authentication mode, run the tool like this:

```sh
./cloudeye-exporter -auth_mode ecsagency
```

This will omit the AK and SK configuration in the `NewCredentialsBuilder` process.

According to the implementation of `github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/basic/basic_icredential.go`:

1. `ProcessAuthRequest()` function (executed for each HTTP request to the Huawei Cloud APIs) checks if the security token needs to be updated through `needUpdateSecurityToken()` function;
2. `needUpdateSecurityToken()` function returns `true` if `authToken`, `AK` and `SK` are empty in the configured credentials;
3. `UpdateSecurityTokenFromMetadata()` function is invoked when `needUpdateSecurityToken()` returns `true`, and invokes `GetCredentialFromMetadata()` function to obtain a temporary AK/SK;
4. `GetCredentialFromMetadata()` function calls the Security Key endpoint from ECS metadata API.