### PR TITLE
feat: add multi-stage Dockerfile and Helm chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+.git
+.github
+.idea
+.vscode
+**/*.md
+cloudservice_metrics/
+vendor/
+**/*_test.go
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.webp
+.DS_Store
+
+# Terragrunt/Terraform caches
+.terragrunt-cache/
+.terraform/
+**/*.tfstate*
+
+# Local artifacts
+dist/
+bin/
+out/
+cloudeye-exporter
+server.log
+clouds.yml
+grafana_dashboard/
+best-practices/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ USER nonroot:nonroot
 EXPOSE 8087
 
 ENTRYPOINT ["/usr/local/bin/cloudeye-exporter"]
-CMD ["-config", "/app/clouds.yml"]
+CMD ["--config", "/app/clouds.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM golang:1.19-alpine AS build
+
+WORKDIR /src
+
+RUN apk add --no-cache ca-certificates=20230506-r0
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+ENV CGO_ENABLED=0
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
+
+RUN go build -trimpath -ldflags="-s -w" -o /out/cloudeye-exporter .
+
+FROM gcr.io/distroless/static-debian11:nonroot
+
+WORKDIR /app
+
+COPY --from=build /out/cloudeye-exporter /usr/local/bin/cloudeye-exporter
+COPY --from=build /src/metric.yml /app/metric.yml
+COPY --from=build /src/logs.yml /app/logs.yml
+COPY --from=build /src/endpoints.yml /app/endpoints.yml
+COPY --from=build /src/i18n.json /app/i18n.json
+COPY --from=build /src/unit_standard_transform.json /app/unit_standard_transform.json
+
+USER nonroot:nonroot
+
+EXPOSE 8087
+
+ENTRYPOINT ["/usr/local/bin/cloudeye-exporter"]
+CMD ["-config", "/app/clouds.yml"]

--- a/charts/cloudeye-exporter/.helmignore
+++ b/charts/cloudeye-exporter/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git
+.gitignore
+.idea
+.vscode
+*.swp
+*.bak
+*.tmp

--- a/charts/cloudeye-exporter/Chart.yaml
+++ b/charts/cloudeye-exporter/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+appVersion: v2.0.31
+description: A Helm chart for HuaweiCloud cloudeye-exporter
+home: https://github.com/huaweicloud/cloudeye-exporter
+keywords:
+  - huaweicloud
+  - prometheus
+  - exporter
+  - cloud-eye
+name: cloudeye-exporter
+sources:
+  - https://github.com/huaweicloud/cloudeye-exporter
+type: application
+version: 0.1.0

--- a/charts/cloudeye-exporter/templates/NOTES.txt
+++ b/charts/cloudeye-exporter/templates/NOTES.txt
@@ -1,0 +1,23 @@
+cloudeye-exporter has been deployed.
+
+Before installing, create a Secret with your clouds.yml:
+
+  kubectl create secret generic {{ .Values.cloudsSecret.name | default "cloudeye-exporter-secret" }} \
+    --from-file=clouds.yml=/path/to/your/clouds.yml \
+    -n {{ .Release.Namespace }}
+
+The clouds.yml format:
+
+  global:
+    prefix: "huaweicloud"
+    scrape_batch_size: 300
+  auth:
+    auth_url: "https://iam.<region>.myhuaweicloud.com/v3"
+    project_name: "<project>"
+    access_key: "<ak>"
+    secret_key: "<sk>"
+    region: "<region>"
+
+Metrics endpoint:
+  kubectl port-forward svc/{{ include "cloudeye-exporter.fullname" . }} 8087:80 -n {{ .Release.Namespace }}
+  curl http://localhost:8087/metrics?services=SYS.ECS,SYS.RDS,SYS.DCS

--- a/charts/cloudeye-exporter/templates/_helpers.tpl
+++ b/charts/cloudeye-exporter/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "cloudeye-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cloudeye-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cloudeye-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cloudeye-exporter.labels" -}}
+helm.sh/chart: {{ include "cloudeye-exporter.chart" . }}
+{{ include "cloudeye-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "cloudeye-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudeye-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "cloudeye-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cloudeye-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "cloudeye-exporter.namespace" -}}
+  {{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}

--- a/charts/cloudeye-exporter/templates/configmap.yaml
+++ b/charts/cloudeye-exporter/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cloudeye-exporter.fullname" . }}
+  namespace: {{ include "cloudeye-exporter.namespace" . }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+data:
+  metric.yml: |
+    {{- if .Values.metrics }}
+    {{- .Values.metrics | toYaml | nindent 4 }}
+    {{- else }}
+    {{- fail "metrics must be set — see cloudservice_metrics/ for available metrics per service" }}
+    {{- end }}
+  logs.yml: |
+    {{- .Values.logsConfig | toYaml | nindent 4 }}

--- a/charts/cloudeye-exporter/templates/deployment.yaml
+++ b/charts/cloudeye-exporter/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudeye-exporter.fullname" . }}
+  namespace: {{ include "cloudeye-exporter.namespace" . }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "cloudeye-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cloudeye-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cloudeye-exporter.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ include "cloudeye-exporter.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config=/etc/cloudeye/clouds.yml"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: clouds-config
+              mountPath: /etc/cloudeye/clouds.yml
+              subPath: clouds.yml
+              readOnly: true
+            - name: metric-config
+              mountPath: /etc/cloudeye/metric.yml
+              subPath: metric.yml
+              readOnly: true
+            - name: metric-config
+              mountPath: /app/logs.yml
+              subPath: logs.yml
+              readOnly: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: clouds-config
+          secret:
+            secretName: {{ .Values.cloudsSecret.name }}
+        - name: metric-config
+          configMap:
+            name: {{ include "cloudeye-exporter.fullname" . }}

--- a/charts/cloudeye-exporter/templates/poddisruptionbudget.yaml
+++ b/charts/cloudeye-exporter/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cloudeye-exporter.fullname" . }}
+  namespace: {{ include "cloudeye-exporter.namespace" . }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cloudeye-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/cloudeye-exporter/templates/secret.yaml
+++ b/charts/cloudeye-exporter/templates/secret.yaml
@@ -1,0 +1,3 @@
+{{- if not .Values.cloudsSecret.name }}
+{{- fail "cloudsSecret.name must be set — create a Secret containing the full clouds.yml content and reference it here" }}
+{{- end }}

--- a/charts/cloudeye-exporter/templates/service.yaml
+++ b/charts/cloudeye-exporter/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudeye-exporter.fullname" . }}
+  namespace: {{ include "cloudeye-exporter.namespace" . }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "cloudeye-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/cloudeye-exporter/templates/serviceaccount.yaml
+++ b/charts/cloudeye-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cloudeye-exporter.serviceAccountName" . }}
+  namespace: {{ include "cloudeye-exporter.namespace" . }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/cloudeye-exporter/templates/servicemonitor.yaml
+++ b/charts/cloudeye-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cloudeye-exporter.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "cloudeye-exporter.namespace" .) | quote }}
+  labels:
+    {{- include "cloudeye-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: {{ .Values.service.name }}
+      path: /metrics
+      params:
+        services:
+          - {{ .Values.serviceMonitor.services | default "SYS.ECS,SYS.RDS,SYS.DCS" | quote }}
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  jobLabel: {{ include "cloudeye-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "cloudeye-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/cloudeye-exporter/values.yaml
+++ b/charts/cloudeye-exporter/values.yaml
@@ -1,0 +1,113 @@
+replicaCount: 1
+
+image:
+  repository: cloudeye-exporter
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8087
+  name: http
+
+serviceMonitor:
+  enabled: false
+  namespace: ""
+  labels: {}
+  interval: 60s
+  scrapeTimeout: 30s
+  # Comma-separated CES services to scrape. Must match metrics: keys below.
+  services: "SYS.ECS,SYS.RDS,SYS.DCS"
+  relabelings: []
+  metricRelabelings: []
+
+# clouds.yml is mounted from a Secret (must contain the full clouds.yml content).
+# Create the Secret beforehand and reference its name here.
+cloudsSecret:
+  name: ""
+
+# metric.yml — which services and metrics to collect.
+# See cloudservice_metrics/ in the repository for the full list of available metrics per service.
+# Example:
+# metrics:
+#   SYS.ECS:
+#     resource: "rms"
+#     dim_metric_name:
+#       instance_id:
+#         - cpu_util
+#         - mem_util
+#   SYS.RDS:
+#     resource: "rms"
+#     dim_metric_name:
+#       postgresql_cluster_id:
+#         - rds001_cpu_util
+#         - rds002_mem_util
+metrics: {}
+
+logsConfig:
+  business:
+    - level: "info"
+      type: "STDOUT"
+      time_format: "2006-01-02 15:04:05 Z07:00"
+      enabled: true
+
+podSecurityContext:
+  runAsGroup: 1001
+  runAsUser: 1001
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  privileged: false
+  readOnlyRootFilesystem: false
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+priorityClassName: ""
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+podLabels: {}
+annotations: {}
+
+deployment:
+  labels: {}
+  annotations: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+nameOverride: ""
+fullnameOverride: ""
+namespaceOverride: ""
+
+livenessProbe: {}
+
+# readinessProbe: {}
+# Example:
+# readinessProbe:
+#   httpGet:
+#     path: /metrics?services=SYS.ECS,SYS.RDS,SYS.DCS
+#     port: http
+#   initialDelaySeconds: 60
+#   periodSeconds: 60
+#   timeoutSeconds: 60
+#   failureThreshold: 3
+readinessProbe: {}


### PR DESCRIPTION
## Summary

Add production-ready multi-stage Dockerfile and a Helm chart for Kubernetes deployments.

---

## Dockerfile

- **Builder stage:** `golang:1.19-alpine` (matches go.mod)
- **Runtime stage:** `gcr.io/distroless/static-debian11:nonroot`
- **Binary:** statically compiled with `CGO_ENABLED=0`, stripped with `-ldflags="-s -w"` and `-trimpath`
- **Multi-arch:** supports `TARGETOS` / `TARGETARCH` build args
- **Security:** runs as `nonroot:nonroot` user, distroless base (no shell, no package manager)
- **Config files baked in:** `metric.yml`, `logs.yml`, `endpoints.yml`, `i18n.json`, `unit_standard_transform.json`
- **Credentials at runtime:** `clouds.yml` is mounted as a volume (not baked into image)

### Validation

```
$ hadolint Dockerfile
(no warnings, no errors)

$ CI=true dive cloudeye-exporter:test
  efficiency: 99.9979 %
  wastedBytes: 613 bytes (613 B)
  userWastedPercent: 0.0037 %
  Result: PASS
```

### Usage

```bash
# Build
docker build -t cloudeye-exporter .

# Run (mount credentials at runtime)
docker run -v /path/to/clouds.yml:/app/clouds.yml cloudeye-exporter

# Multi-arch build
docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=arm64 -t cloudeye-exporter .
```

---

## Helm Chart (`charts/cloudeye-exporter`)

A production-ready Helm chart for deploying cloudeye-exporter on Kubernetes.

### Features

- **Secret-based credentials:** `clouds.yml` mounted from a user-provided Secret (not stored in chart)
- **ConfigMap-driven config:** `metric.yml` and `logs.yml` rendered from `values.yaml` — no manual ConfigMap management
- **ServiceMonitor:** optional Prometheus Operator integration with configurable scrape interval, params, relabelings
- **Security hardened:** `runAsNonRoot`, `seccompProfile: RuntimeDefault`, dropped capabilities, `automountServiceAccountToken: false`
- **High availability:** optional `PodDisruptionBudget`, `topologySpreadConstraints`, pod anti-affinity
- **Fail-fast validation:** `helm install` errors immediately if `cloudsSecret.name` or `metrics` are not set

### Usage

```bash
# 1. Create a Secret with your clouds.yml
kubectl create secret generic cloudeye-exporter-secret \
  --from-file=clouds.yml=/path/to/clouds.yml \
  -n observability

# 2. Install
helm upgrade --install cloudeye-exporter ./charts/cloudeye-exporter \
  --set cloudsSecret.name=cloudeye-exporter-secret \
  -n observability
```
---

## Related

This PR picks up where two earlier community attempts left off:

- #23 — introduced Docker build and Helm chart (open since 2020, no review)
- #5 — files formatting, logging fixes and Helm chart with ServiceMonitor (open since 2019, no review)

cc @xiaoyingustb @cxl123156 — would love to get your eyes on this when you have a chance.